### PR TITLE
Use .startswith() method instead of 'x in y' to match sample names

### DIFF
--- a/abil_urdocaller.py
+++ b/abil_urdocaller.py
@@ -16,7 +16,7 @@ import shutil
 from itertools import islice
 import operator
 import urdohelper
-VERSION = """SMORE'D ALPHA.4.2 (updated : April 09, 2019)"""
+VERSION = """SMORE'D ALPHA.4.3 (updated : April 15, 2019)"""
 LICENSE = """
 SMORE'D is free for academic users and requires permission before any
 commercial or government usage of any version of this code/algorithm.

--- a/urdohelper.py
+++ b/urdohelper.py
@@ -7,7 +7,7 @@ def link_reads(sample_freq, read_ones):
     for sample_name, value in sample_freq.items():
         if value > 1:
             sample_first_reads = [
-                x for x in read_ones if sample_name in x]
+                x for x in read_ones if x.startswith(sample_name)]
             for sample_read_one in sample_first_reads:
                 combined_file_one = \
                     sample_name + "_L999_R1_" + \
@@ -42,7 +42,7 @@ def link_reads(sample_freq, read_ones):
                 else:
                     logging.debug(f"Preprocessing: [Merging lanes] Merged read for {sample_name}")
         else:
-            full_sample_name = [x for x in read_ones if sample_name in x]
+            full_sample_name = [x for x in read_ones if x.startswith(sample_name)]
             sys_call_sample_one = f"ln -sL {__directory__}/{full_sample_name[0]} \
                                             {TMPDIR}/{full_sample_name[0]}"
             try:


### PR DESCRIPTION
Fix containment problems with sample names